### PR TITLE
fix: update title to Business R&D Dashboard v33

### DIFF
--- a/apps/dashboard/app/layout.tsx
+++ b/apps/dashboard/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import React from 'react';
 
 export const metadata: Metadata = {
-  title: 'Business R&D Dashboard v3',
+  title: 'Business R&D Dashboard v33',
   description: 'Manual runner UI for the AI-agent business R&D workflow.',
 };
 


### PR DESCRIPTION
## Summary
Update the dashboard title from v3 to v33 per issue #56.

## Changes
- **apps/dashboard/app/layout.tsx**: Changed `title` from `Business R&D Dashboard v3` to `Business R&D Dashboard v33`

Closes #56